### PR TITLE
chore(release): Sync with v0.1.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the CommitPulse extension will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+[0;34m[INFO][0m Generating changelog from commits since v0.1.33...
+## [0.1.34] - 2026-06-09
+
 [0;34m[INFO][0m Generating changelog from commits since v0.1.32...
 ## [0.1.33] - 2026-06-09
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gitr",
   "displayName": "CommitPulse - Git Analytics Pipeline",
   "description": "CommitPulse transforms your Git repositories into actionable engineering intelligence. It extracts commit history, links commits to Jira and Linear issues, syncs contributor data from GitHub, and calculates team-level metrics — all from within VS Code. Data is stored locally in PostgreSQL (via Docker), keeping your engineering analytics private, fast, and under your control. Public repo: https://github.com/antonajp/CommitPulse",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "publisher": "ImproviseLabs",
   "license": "MIT",
   "repository": {

--- a/src/database/queries/dev-profile-queries.ts
+++ b/src/database/queries/dev-profile-queries.ts
@@ -42,7 +42,7 @@ export const QUERY_DEV_PROFILE_VELOCITY_VS_LOC = `
   ),
   dev_jira_points AS (
     SELECT
-      DATE_TRUNC('week', jd.resolved_date)::date AS week_start,
+      DATE_TRUNC('week', jd.status_change_date)::date AS week_start,
       COALESCE(SUM(jd.calculated_story_points), 0)::int AS story_points,
       COUNT(DISTINCT jd.jira_key)::int AS issue_count
     FROM jira_detail jd
@@ -50,7 +50,7 @@ export const QUERY_DEV_PROFILE_VELOCITY_VS_LOC = `
       jd.assignee = cc.email OR jd.assignee = cc.login OR jd.assignee = cc.full_name
     )
     WHERE cc.login = $1
-      AND jd.resolved_date >= $2
+      AND jd.status_change_date >= $2
       AND jd.status IN ('Done', 'Closed', 'Resolved')
     GROUP BY week_start
   ),


### PR DESCRIPTION
## Summary
Synced from private repository for marketplace release v0.1.34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)